### PR TITLE
Added nrdbq command for Elasticsearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-netrunner",
   "description": "A hubot script to show Android Netrunner card info",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "author": "Omar Delarosa <thedelarosa@gmail.com>",
   "license": "MIT",
   "keywords": [

--- a/src/netrunner.coffee
+++ b/src/netrunner.coffee
@@ -73,6 +73,9 @@ formatNRDBResponse = (msg, card, opts) ->
   if card.type == "Identity"
     text += "*Minimum Deck Size*: #{card.minimumdecksize}\n"
     text += "*Influence Limit*: #{card.influencelimit}\n"
+    #add runner base link
+    if card.baselink
+      text += ":linknr: : #{card.baselink}\n"
 
 #add trash costs for assets and upgrades
   if card.type == "Asset" || card.type == "Upgrade"

--- a/src/netrunner.coffee
+++ b/src/netrunner.coffee
@@ -9,6 +9,7 @@
 #  hubot nrdb {card_attribute} {query} - responds with card info from netrunner db
 #  hubot nrdb {card_attribute} {query} -l - responds with list of first 10 matches
 #  hubot nrdb {card_attribute} {query} -n - responds with only card image, no text
+#  hubot nrdbq {query | attribute:query [ [OR|AND] attribute2:query2] }
 #
 # Author:
 #  omardelarosa
@@ -167,6 +168,22 @@ nrdb = (msg) ->
           console.log e.stack
           msg.send "Error parsing response from NetRunner DB"
 
+nrdbq = (msg) ->
+  q = msg.match[1]
+  url = "http://netrunner.delarosa.io/search/"
+  concatUrl = "#{url}#{q}"
+  msg.http(concatUrl)
+    .get() (err, res, body) ->
+      if err
+        console.log err
+      content = JSON.parse body
+      if content.length == 0
+        msg.send "No matches found for #{q}"
+      else
+        content.forEach (c) ->
+          formatNRDBResponse(msg, c, {})
+
+
 fetchCard = (msg) ->
   query = msg.match[0].split(' ').slice(2).join('%20')
   url = "http://ancur.wikia.com/api/v1/Search/List/?query=" + query + "&limit=1&namespaces=0%2C14"
@@ -197,3 +214,6 @@ module.exports = (robot) ->
  
   robot.respond /nrdb (.*)\b/i, (msg) ->
     nrdb(msg)
+
+  robot.respond /nrdbq (.*)/i, (msg) ->
+    nrdbq(msg)


### PR DESCRIPTION
I added a new command called `nrdbq {query}`.  It allows faster, more open-ended queries using [Elasticsearch's Query String DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html).  So, for example.  `nrdbq title:desperado OR title:tgtbt` would return:

```
*Title*: Desperado
*Faction*: :criminal:
*Type*: Hardware  - Console
*Install Cost*: 3
*Influence*: 3
*Set*: Core Set
*Text*: +1:memoryunit:
Gain 1:credits: whenever you make a successful run.
Limit 1 *console* per player.
*NRDBURL*: http://netrunnerdb.com/en/card/01024

http://netrunnerdb.com/bundles/netrunnerdbcards/images/cards/en/01024.png

*Title*: TGTBT
*Faction*: :nbn:
*Type*: Agenda  - Ambush
*Adv/Pts*: 3 /1
*Set*: True Colors
*Text*: If TGTBT is accessed from R&D, the Runner must reveal it.
When the Runner accesses TGTBT, give the Runner 1 tag.
*NRDBURL*: http://netrunnerdb.com/en/card/04075

http://netrunnerdb.com/bundles/netrunnerdbcards/images/cards/en/04075.png
```

Not specifying the attribute would just do a full-text search of all cards.  For example, `nrdbq desperado` would return:

```
*Title*: Desperado
*Faction*: :criminal:
*Type*: Hardware  - Console
*Install Cost*: 3
*Influence*: 3
*Set*: Core Set
*Text*: +1:memoryunit:
Gain 1:credits: whenever you make a successful run.
Limit 1 *console* per player.
*NRDBURL*: http://netrunnerdb.com/en/card/01024

http://netrunnerdb.com/bundles/netrunnerdbcards/images/cards/en/01024.png
```
